### PR TITLE
[iOS-173]Enhance Shoppettes view with pagination support

### DIFF
--- a/TSL SDK.xcodeproj/project.pbxproj
+++ b/TSL SDK.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 60;
+	objectVersion = 56;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -11,6 +11,8 @@
 		1B737FAA2EABEA5A008B92E2 /* Talkshoplive in Frameworks */ = {isa = PBXBuildFile; productRef = 1B737FA92EABEA5A008B92E2 /* Talkshoplive */; };
 		1B737FAC2EABEFA5008B92E2 /* ShoppettesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B737FAB2EABEFA5008B92E2 /* ShoppettesView.swift */; };
 		1B82F7D12DE9FBDF0092CEF0 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B82F7D02DE9FBDF0092CEF0 /* Constants.swift */; };
+		1BB28E682ED0DDEB00EFE786 /* String_Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BB28E672ED0DDEB00EFE786 /* String_Extension.swift */; };
+		1BB28E6B2ED0FC6D00EFE786 /* Talkshoplive in Frameworks */ = {isa = PBXBuildFile; productRef = 1BB28E6A2ED0FC6D00EFE786 /* Talkshoplive */; };
 		67106EAE2C658E6600E4D7E0 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67106EAD2C658E6600E4D7E0 /* HomeViewModel.swift */; };
 		67472D072C0DF64E0062AAE4 /* GiphyUISDK in Frameworks */ = {isa = PBXBuildFile; productRef = 67472D062C0DF64E0062AAE4 /* GiphyUISDK */; };
 		67472D0A2C0DF6670062AAE4 /* Talkshoplive in Frameworks */ = {isa = PBXBuildFile; productRef = 67472D092C0DF6670062AAE4 /* Talkshoplive */; };
@@ -61,6 +63,7 @@
 /* Begin PBXFileReference section */
 		1B737FAB2EABEFA5008B92E2 /* ShoppettesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShoppettesView.swift; sourceTree = "<group>"; };
 		1B82F7D02DE9FBDF0092CEF0 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
+		1BB28E672ED0DDEB00EFE786 /* String_Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = String_Extension.swift; sourceTree = "<group>"; };
 		67106EAD2C658E6600E4D7E0 /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
 		67472D0B2C0DF9010062AAE4 /* GiphyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiphyView.swift; sourceTree = "<group>"; };
 		67472D0F2C0DFA290062AAE4 /* ChatViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewModel.swift; sourceTree = "<group>"; };
@@ -98,6 +101,7 @@
 				1B737FAA2EABEA5A008B92E2 /* Talkshoplive in Frameworks */,
 				67472D072C0DF64E0062AAE4 /* GiphyUISDK in Frameworks */,
 				67EB7B3D2BEEB07200B059E9 /* Talkshoplive in Frameworks */,
+				1BB28E6B2ED0FC6D00EFE786 /* Talkshoplive in Frameworks */,
 				67472D0A2C0DF6670062AAE4 /* Talkshoplive in Frameworks */,
 				1B28836F2EC7A106008CFFF1 /* Talkshoplive in Frameworks */,
 				675F39A42BE2F3AD00A0DA1D /* Talkshoplive in Frameworks */,
@@ -121,6 +125,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		1BB28E662ED0DDDE00EFE786 /* Common */ = {
+			isa = PBXGroup;
+			children = (
+				1BB28E672ED0DDEB00EFE786 /* String_Extension.swift */,
+			);
+			path = Common;
+			sourceTree = "<group>";
+		};
 		6723152F2B623CB10052D39A /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -209,6 +221,7 @@
 		D17DA7742B5F10FD00ED9BBF /* TSL SDK */ = {
 			isa = PBXGroup;
 			children = (
+				1BB28E662ED0DDDE00EFE786 /* Common */,
 				679208372C6C0D7400957DE4 /* Products */,
 				67472D0E2C0DFA0F0062AAE4 /* Chat */,
 				674BAFE62BB47A8D004AEA9E /* ShowsList */,
@@ -275,6 +288,7 @@
 				67472D092C0DF6670062AAE4 /* Talkshoplive */,
 				1B737FA92EABEA5A008B92E2 /* Talkshoplive */,
 				1B28836E2EC7A106008CFFF1 /* Talkshoplive */,
+				1BB28E6A2ED0FC6D00EFE786 /* Talkshoplive */,
 			);
 			productName = "TSL SDK";
 			productReference = D17DA7722B5F10FD00ED9BBF /* TSL SDK.app */;
@@ -350,7 +364,7 @@
 			mainGroup = D17DA7692B5F10FD00ED9BBF;
 			packageReferences = (
 				67472D052C0DF64E0062AAE4 /* XCRemoteSwiftPackageReference "giphy-ios-sdk" */,
-				1B28836D2EC7A106008CFFF1 /* XCLocalSwiftPackageReference "../../../iOS-SDK/ios-sdk" */,
+				1BB28E692ED0FC6D00EFE786 /* XCRemoteSwiftPackageReference "ios-sdk" */,
 			);
 			productRefGroup = D17DA7732B5F10FD00ED9BBF /* Products */;
 			projectDirPath = "";
@@ -394,6 +408,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1BB28E682ED0DDEB00EFE786 /* String_Extension.swift in Sources */,
 				D17DA7782B5F10FD00ED9BBF /* ContentView.swift in Sources */,
 				D104548C2BA0BBB3003877BA /* LiveChat.swift in Sources */,
 				674BAFE82BB47A9B004AEA9E /* PlayerView.swift in Sources */,
@@ -767,14 +782,15 @@
 		};
 /* End XCConfigurationList section */
 
-/* Begin XCLocalSwiftPackageReference section */
-		1B28836D2EC7A106008CFFF1 /* XCLocalSwiftPackageReference "../../../iOS-SDK/ios-sdk" */ = {
-			isa = XCLocalSwiftPackageReference;
-			relativePath = "../../../iOS-SDK/ios-sdk";
-		};
-/* End XCLocalSwiftPackageReference section */
-
 /* Begin XCRemoteSwiftPackageReference section */
+		1BB28E692ED0FC6D00EFE786 /* XCRemoteSwiftPackageReference "ios-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/TalkShopLive/ios-sdk";
+			requirement = {
+				branch = development;
+				kind = branch;
+			};
+		};
 		67472D052C0DF64E0062AAE4 /* XCRemoteSwiftPackageReference "giphy-ios-sdk" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Giphy/giphy-ios-sdk";
@@ -792,6 +808,11 @@
 		};
 		1B737FA92EABEA5A008B92E2 /* Talkshoplive */ = {
 			isa = XCSwiftPackageProductDependency;
+			productName = Talkshoplive;
+		};
+		1BB28E6A2ED0FC6D00EFE786 /* Talkshoplive */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 1BB28E692ED0FC6D00EFE786 /* XCRemoteSwiftPackageReference "ios-sdk" */;
 			productName = Talkshoplive;
 		};
 		67472D062C0DF64E0062AAE4 /* GiphyUISDK */ = {

--- a/TSL SDK.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TSL SDK.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -16,7 +16,7 @@
       "location" : "https://github.com/TalkShopLive/ios-sdk",
       "state" : {
         "branch" : "development",
-        "revision" : "7e1dfe3b314396aa736a23943a77c50589c97333"
+        "revision" : "041a8e3271a7568df17b41d0ce881578af3994de"
       }
     },
     {
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pubnub/swift.git",
       "state" : {
-        "revision" : "d1f82968fa88caff521c6b623fe69b28444761cc",
-        "version" : "8.3.1"
+        "revision" : "0639f7c76bbf7e92e78f39717a078d04e60f492e",
+        "version" : "9.3.5"
       }
     }
   ],

--- a/TSL SDK/Chat/LiveChat.swift
+++ b/TSL SDK/Chat/LiveChat.swift
@@ -10,7 +10,7 @@ import Talkshoplive
 import GiphyUISDK
 
 
-var defultShowID =  "KsqM-Z5Z8eim" // threaded message
+
 struct LiveChat: View {
     @State private var refreshCount = 0 // Counter to track refreshes
 

--- a/TSL SDK/Common/String_Extension.swift
+++ b/TSL SDK/Common/String_Extension.swift
@@ -1,0 +1,31 @@
+//
+//  String_Extension.swift
+//  TSL SDK
+//
+//  Created by Talkshoplive on 2025-11-21.
+//
+
+import Foundation
+
+public extension String {
+    func toFormattedDate(format: String = "dd MMM, yyyy") -> String {
+        let isoFormatter = ISO8601DateFormatter()
+        isoFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds] // handle .000Z
+        
+        // Try parsing
+        guard let date = isoFormatter.date(from: self) else {
+            // Fallback: try without fractional seconds
+            isoFormatter.formatOptions = [.withInternetDateTime]
+            guard let fallbackDate = isoFormatter.date(from: self) else {
+                return "" // could not parse
+            }
+            return DateFormatter.localizedString(from: fallbackDate, dateStyle: .medium, timeStyle: .none)
+        }
+        
+        let formatter = DateFormatter()
+        formatter.dateFormat = format
+        formatter.locale = Locale(identifier: "en_US")
+        
+        return formatter.string(from: date)
+    }
+}

--- a/TSL SDK/Constants.swift
+++ b/TSL SDK/Constants.swift
@@ -8,3 +8,4 @@
 import Foundation
 
 let clientKey: String = ""
+var defaultShowID =  "n4K6JLZ4cVKX"

--- a/TSL SDK/ShoppettesView.swift
+++ b/TSL SDK/ShoppettesView.swift
@@ -11,16 +11,21 @@ import Talkshoplive
 struct ShoppettesView: View {
     // MARK: - State Properties
     @State private var shoppettesResult: String = ""
-    @State private var channelId: String = ""
-    @State private var shoppettes: [ShoppetteData] = []
+    @State private var channelId: String = "442" // WalmartChannelId -> Staging
+    @State private var shoppettes: [ShoppettesData] = []
+    @State private var shoppettesMetaData: ShoppettesMeta?
     @State private var shoppettesInstance: Shoppettes?
     @State private var isLoading = false
-
+    
+    // Page is set from API response instead of manually incrementing
+    @State private var currentPage: Int = 1
+    
     // MARK: - UI Body
     var body: some View {
         NavigationView {
             ScrollView {
                 VStack(spacing: 20) {
+                    
                     // Input Field
                     VStack(alignment: .leading, spacing: 8) {
                         Text("Channel ID")
@@ -35,7 +40,10 @@ struct ShoppettesView: View {
                                 .disableAutocorrection(true)
                                 .autocapitalization(.none)
                             
-                            Button(action: fetchShoppettes) {
+                            Button(action: {
+                                currentPage = 1  // reset
+                                fetchShoppettes()
+                            }) {
                                 HStack(spacing: 6) {
                                     if isLoading {
                                         ProgressView()
@@ -58,22 +66,74 @@ struct ShoppettesView: View {
                     .background(Color(.systemGray6))
                     .cornerRadius(12)
                     .shadow(color: .gray.opacity(0.2), radius: 4, x: 0, y: 2)
-
-                    // Shoppettes List
+                    
+                    
+                    // MARK: - Shoppettes List
                     if isLoading {
                         ProgressView("Fetching shoppettes…")
                             .padding()
+                        
                     } else if !shoppettes.isEmpty {
                         LazyVStack(spacing: 14) {
                             ForEach(shoppettes.indices, id: \.self) { index in
-                                ShoppetteCardView(shoppette: shoppettes[index], index: index)
+                                ShoppetteCardView(shoppette: shoppettes[index])
                             }
                         }
                         .padding(.horizontal)
+                        
+                        // MARK: Pagination UI using API’s next/prev
+                        if let meta = shoppettesMetaData {
+                            VStack(spacing: 12) {
+                                
+                                HStack(spacing: 20) {
+                                    // PREV button
+                                    Button(action: {
+                                        if let prev = meta.prevPage {
+                                            currentPage = prev
+                                            fetchShoppettes()
+                                        }
+                                    }) {
+                                        Text("◀ Prev")
+                                            .padding()
+                                            .frame(maxWidth: .infinity)
+                                            .background(meta.prevPage != nil ? Color.blue : Color.gray.opacity(0.4))
+                                            .foregroundColor(.white)
+                                            .cornerRadius(10)
+                                    }
+                                    .disabled(meta.prevPage == nil)
+                                    
+                                    
+                                    // NEXT button
+                                    Button(action: {
+                                        if let next = meta.nextPage {
+                                            currentPage = next
+                                            fetchShoppettes()
+                                        }
+                                    }) {
+                                        Text("Next ▶")
+                                            .padding()
+                                            .frame(maxWidth: .infinity)
+                                            .background(meta.nextPage != nil ? Color.blue : Color.gray.opacity(0.4))
+                                            .foregroundColor(.white)
+                                            .cornerRadius(10)
+                                    }
+                                    .disabled(meta.nextPage == nil)
+                                }
+                                
+                                Text("Page \(currentPage)\(meta.totalPages != nil ? " / \(meta.totalPages!)" : "")")
+                                    .font(.footnote)
+                                    .foregroundColor(.secondary)
+                                
+                            }
+                            .padding(.horizontal)
+                            .padding(.bottom, 25)
+                        }
+                        
                     } else if !shoppettesResult.isEmpty {
                         Text(shoppettesResult)
                             .foregroundColor(.red)
                             .padding()
+                        
                     } else {
                         VStack(spacing: 8) {
                             Image(systemName: "cart.badge.questionmark")
@@ -91,62 +151,94 @@ struct ShoppettesView: View {
             .onAppear { initializeSDK() }
         }
     }
-
-    // MARK: - Shoppette Card
+    
+    // MARK: - Shoppette Card View
     struct ShoppetteCardView: View {
-        let shoppette: ShoppetteData
-        let index: Int
+        let shoppette: ShoppettesData
 
         var body: some View {
-            VStack(alignment: .leading, spacing: 8) {
-                Text("Shoppette \(index + 1)")
-                    .font(.headline)
-                    .foregroundColor(.blue)
-                
-                Group {
-                    HStack {
-                        Text("ID:")
-                            .fontWeight(.semibold)
-                        Text("\(shoppette.id ?? 0)")
+            HStack(alignment: .top, spacing: 12) {
+                // MARK: - Left: Image
+                AsyncImage(url: URL(string: shoppette.thumbnailUrl ?? "")) { phase in
+                    if let image = phase.image {
+                        image
+                            .resizable()
+                            .scaledToFill()
+                    } else if phase.error != nil {
+                        Image(systemName: "photo")
+                            .resizable()
+                            .scaledToFit()
+                            .foregroundColor(.gray)
+                            .opacity(0.5)
+                    } else {
+                        ProgressView()
                     }
-                    HStack {
-                        Text("Name:")
-                            .fontWeight(.semibold)
-                        Text(shoppette.name ?? "N/A")
+                }
+                .frame(width: 50, height: 100)
+                .background(Color.gray.opacity(0.1))
+                .cornerRadius(12)
+                .clipped()
+
+                // MARK: - Right: Info
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(shoppette.name ?? "No Name")
+                        .font(.headline)
+                        .foregroundColor(.blue)
+
+                    if let desc = shoppette.description, !desc.isEmpty {
+                        Text(desc)
+                            .font(.subheadline)
+                            .foregroundColor(.primary)
+                            .lineLimit(2)
                     }
-                    HStack {
-                        Text("Description:")
-                            .fontWeight(.semibold)
-                        Text(shoppette.description ?? "N/A")
-                    }
-                    HStack {
-                        Text("Status:")
-                            .fontWeight(.semibold)
-                        Text(shoppette.status ?? "N/A")
-                    }
+
                     HStack {
                         Text("Video Status:")
                             .fontWeight(.semibold)
                         Text(shoppette.videoStatus ?? "N/A")
+                        /*
+                         VIDEO_STATUS_LIST = [
+                         'Deleting','Deleted','Draft','Scheduled','Ready To Publish','Published','Publishing','Retrying to publish','Error Publishing','Published Without Audio','Disconnected'
+                         ];
+                         */
                     }
+                    .font(.subheadline)
+
+                    HStack {
+                        Text("Status:")
+                            .fontWeight(.semibold)
+                        Text(shoppette.status ?? "N/A")
+                        /*
+                         VIDEO_PROCESSING_STATUS_LIST = [
+                         'processing','completed','error','not_started'
+                         ];
+                         */
+                    }
+                    .font(.subheadline)
+                    
+                    HStack {
+                        Text("Published Date:")
+                            .fontWeight(.semibold)
+                        Text(shoppette.publishedAt?.toFormattedDate() ?? "N/A")
+                    }
+                    .font(.subheadline)
                 }
-                .font(.subheadline)
-                .foregroundColor(.primary)
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
             .padding()
-            .frame(maxWidth: .infinity, alignment: .leading)
             .background(Color.white)
             .cornerRadius(12)
             .shadow(color: .gray.opacity(0.15), radius: 5, x: 0, y: 3)
         }
     }
 
+    
     // MARK: - SDK Methods
     private func initShoppettes() {
         let token = "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoyOTAxLCJqdGkiOiJjOTQwZTZjNTBjZTRlYWRiY2Y1ODAxNTBhNGUzZjRiOCIsImV4cCI6MTc2NTU1OTc2M30.oXZKnQA12d0gI-VTNwbtOQDDmaXwJz5GGDHydgOLNR4"
         self.shoppettesInstance = Shoppettes(jwtToken: token)
     }
-
+    
     private func initializeSDK() {
         Talkshoplive.TalkShopLive(clientKey: clientKey, debugMode: true, testMode: true) { result in
             switch result {
@@ -159,27 +251,31 @@ struct ShoppettesView: View {
             }
         }
     }
-
+    
     private func fetchShoppettes() {
         shoppettesResult = ""
         shoppettes.removeAll()
         isLoading = true
-
+        
         guard let shoppettesInstance = shoppettesInstance else {
             shoppettesResult = "Shoppettes not initialized."
             isLoading = false
             return
         }
-
-        shoppettesInstance.getShoppettes(channelId: channelId) { result in
+        
+        shoppettesInstance.getShoppettes(channelId: channelId, page: currentPage) { result in
             DispatchQueue.main.async {
                 isLoading = false
                 switch result {
-                case .success(let data):
-                    self.shoppettes = data
-                    if data.isEmpty {
+                case let .success((shoppettesArray, meta)):
+                    self.shoppettes = shoppettesArray
+                    self.shoppettesMetaData = meta
+                    self.currentPage = meta.currentPage ?? currentPage // sync from server
+                    
+                    if shoppettesArray.isEmpty {
                         self.shoppettesResult = "No shoppettes found for channel \(channelId)."
                     }
+                    
                 case .failure(let error):
                     self.shoppettesResult = "Error: \(error.localizedDescription)"
                 }

--- a/TSL SDK/ShowView.swift
+++ b/TSL SDK/ShowView.swift
@@ -8,8 +8,6 @@
 import SwiftUI
 import Talkshoplive
 
-let defaultShowID = "22Nlc9y9kUih"
-
 struct ShowView: View {
     // MARK: - State Properties
     @State private var timer: Timer?


### PR DESCRIPTION
- Updated getShoppettes API call to handle pagination completions.
- Managed ShoppettesMeta object for current, previous, and next pages.
- Add edPrev and Next buttons in UI for navigating Shoppettes pages.
- Implemented pagination logic for both Prev and Next actions.