### PR TITLE
Repoint SPM ios-sdk pin to pubnub-xcode26-fix branch

### DIFF
--- a/TSL SDK.xcodeproj/project.pbxproj
+++ b/TSL SDK.xcodeproj/project.pbxproj
@@ -787,7 +787,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/TalkShopLive/ios-sdk";
 			requirement = {
-				branch = development;
+				branch = "pubnub-xcode26-fix";
 				kind = branch;
 			};
 		};

--- a/TSL SDK.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TSL SDK.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Giphy/giphy-ios-sdk",
       "state" : {
-        "revision" : "9a3970c258ef5cc005f9359ba4c6a344fe062abe",
-        "version" : "2.2.15"
+        "revision" : "3ba672878445c53c8cb87d57c3ae5cc1f3166b5b",
+        "version" : "2.3.2"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/TalkShopLive/ios-sdk",
       "state" : {
-        "branch" : "development",
-        "revision" : "041a8e3271a7568df17b41d0ce881578af3994de"
+        "branch" : "pubnub-xcode26-fix",
+        "revision" : "9c96c395fd0ba472a2d8d1e72744310fa2506d71"
       }
     },
     {
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pubnub/swift.git",
       "state" : {
-        "revision" : "0639f7c76bbf7e92e78f39717a078d04e60f492e",
-        "version" : "9.3.5"
+        "revision" : "ff529423b2480413d8006cd2ced9bc65aa3e583e",
+        "version" : "10.1.5"
       }
     }
   ],


### PR DESCRIPTION
## Summary

Repoints the SPM dependency on `TalkShopLive/ios-sdk` from the `development` branch to the new `pubnub-xcode26-fix` branch so the sample app pulls the PubNub 10.1.5 transitive bump that fixes the Walmart Xcode 26 `.xcresult` coverage issue.

**Companion PR:** TalkShopLive/ios-sdk#139 — bumps `PubNubSDK` 9.3.5 → 10.1.5 (one-line `Package.swift` change).

Full investigation: [`PUBNUB_XCODE26_AUDIT.md`](../tree/development/PUBNUB_XCODE26_AUDIT.md) (workspace root).

## Changes

- `TSL SDK.xcodeproj/project.pbxproj`: `XCRemoteSwiftPackageReference "ios-sdk"` requirement branch `development` → `pubnub-xcode26-fix` (one line)
- `TSL SDK.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved`: re-resolved — `PubNubSDK` transitively bumps to `10.1.5`

```diff
TSL SDK.xcodeproj/project.pbxproj:790:
-    branch = development;
+    branch = "pubnub-xcode26-fix";
```

## Public API / app code impact — none

App code imports only `Talkshoplive`, never `PubNubSDK` directly (verified by grep across `TSL SDK/*.swift`). No Swift source changes in this PR.

## Validation

| Check | Result |
|-------|--------|
| `xcodebuild -resolvePackageDependencies` against `pubnub-xcode26-fix` | ✅ Resolves to `PubNubSDK 10.1.5` and `Talkshoplive @ pubnub-xcode26-fix (9c96c39)` |
| `xcodebuild test -enableCodeCoverage YES` on Xcode 26.2 + iOS Simulator 26.3.1 (Walmart reproducer) | ✅ `** TEST SUCCEEDED **`, all 8 tests pass, `.xcresult` coverage **present** for `TSL SDK.app` (8.09%) and both xctest bundles (100% / 100%). |
| Control: same invocation against unmodified `main` (PubNub 9.3.5) | ⚠️ Produces **byte-for-byte identical** coverage numbers. Bug class not reproducible on Xcode 26.2 + iOS 26.3.1 with either PubNub version. See companion PR #139 "Reproducer caveats". |
| Live chat smoke flow (connect / publish / receive / like-unlike / history / reconnect) | ⏭️ Not run — requires valid TSL backend `clientKey` + show key + PubNub publish/subscribe keys. The hardcoded `0GmN76SBDdHRsGLRDcmVzpURj` in `TalkShopLiveTests.testInitializeSDK` returns `AUTHENTICATION_EXCEPTION` against the live test backend, so the SDK can't be initialized in a sandbox without working credentials. App **does** launch cleanly under PubNub 10.1.5 on iOS 26.3.1 (4 `TSL_SDKUITestsLaunchTests.testLaunch()` runs all pass). |

## Notes for reviewer

- This PR's pbxproj branch pin is **temporary**. Companion `ios-sdk` PR will be tagged `9.4.0-rc1` (RC, pre-release; SPM default ranges skip it so other consumers stay on `9.3.x`). After Walmart confirms `.xcresult` coverage works in their CI, GA tag is `10.0.0`.
- This PR's pin should switch from `branch = "pubnub-xcode26-fix"` to `kind = exactVersion` with `9.4.0-rc1` (RC validation phase) or `kind = upToNextMajorVersion` with `10.0.0` (after GA).
- **Do not merge before TalkShopLive/ios-sdk#139 is merged AND tagged** — the branch pin would otherwise become stale once the SDK branch is deleted post-merge.

`Package.resolved` also auto-bumped Giphy `2.2.15 → 2.3.2` when SPM re-resolved (Giphy is on `upToNextMajorVersion`, picked latest within range). Lockfile change, not production code; flagged for awareness.

## Related

- Companion PR: TalkShopLive/ios-sdk#139
- Audit: [`PUBNUB_XCODE26_AUDIT.md`](../tree/development/PUBNUB_XCODE26_AUDIT.md)
- Changelog: [`PUBNUB_XCODE26_CHANGELOG.md`](../tree/development/PUBNUB_XCODE26_CHANGELOG.md)

## Test plan

- [ ] CI green on this branch
- [ ] After companion `ios-sdk` PR merges and is tagged `9.4.0-rc1`, repoint this PR to pin the tag (drop the branch reference)
- [ ] Walmart confirms `.xcresult` coverage in their CI on this branch (or the tagged RC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
